### PR TITLE
Send SIGKILL to ueberzug on exit

### DIFF
--- a/lfrun
+++ b/lfrun
@@ -3,7 +3,7 @@ export FIFO_UEBERZUG="/tmp/lf-ueberzug-${PPID}"
 
 function cleanup {
 	rm "$FIFO_UEBERZUG" 2>/dev/null
-	pkill -P $$
+	pkill -KILL -P $$
 }
 
 mkfifo "$FIFO_UEBERZUG"


### PR DESCRIPTION
For some reason, ueberzug ignores SIGTERM which causes the instance to remain active even after quitting lf. This causes image previews to remain layered on top of the terminal and hogging system memory when the terminal is closed.