### PR TITLE
Remove bugged CSV preview

### DIFF
--- a/preview
+++ b/preview
@@ -33,14 +33,6 @@ case "$(printf "%s\n" "$1" | awk '{print tolower($0)}')" in
 	*odt,*.ods,*.odp,*.sxw) odt2txt "$1" ;;
 	*.doc) catdoc "$1" ;;
 	*.docx) docx2txt "$1" - ;;
-	*.csv)
-		if command -v bat > /dev/null 2>&1
-		then
-			bat --color=auto --style=plain --pager=never "$1" | 'sed s/,/\n/g'
-		else
-			sed 's/,/\n/g' "$1"
-		fi
-		;;
 	*.wav|*.mp3|*.flac|*.m4a|*.wma|*.ape|*.ac3|*.og[agx]|*.spx|*.opus|*.as[fx])
 		exiftool "$1"
 		;;


### PR DESCRIPTION
Removed bugged CSV preview. The piped sed statement is invalid syntax, and splitting by lines does not make sense for a CSV, which is what the sed statement intends to do. When the statement is removed, the * case will be used and will correctly show CSV files.