### PR TITLE
Fix Makefile issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,19 +2,19 @@ install:
 	sudo cp ./lfrun /usr/bin/lfrun
 	sudo chmod +x /usr/bin/lfrun
 	@if [ ! -d ~/.config/lf/ ]; then\
-		mkdir ~/.config/lf ;\
+		mkdir -p ~/.config/lf ;\
 	fi
 	cp ./cleaner ~/.config/lf/cleaner
 	chmod +x ~/.config/lf/cleaner
 	cp ./preview ~/.config/lf/preview
 	chmod +x ~/.config/lf/preview
-	@if [ -z "$(sed -n '/set previewer/p' ~/.config/lf/lfrc)" ]; then\
+	@if [ -z "$(shell sed -n '/set previewer/p' ~/.config/lf/lfrc)" ]; then\
 		sed -i '1 i\set previewer ~/.config/lf/preview' ~/.config/lf/lfrc ;\
 	fi
-	@if [ -z "$(sed -n '/set cleaner/p' ~/.config/lf/lfrc)" ]; then\
+	@if [ -z "$(shell sed -n '/set cleaner/p' ~/.config/lf/lfrc)" ]; then\
 		sed -i '1 i\set cleaner ~/.config/lf/cleaner' ~/.config/lf/lfrc ;\
 	fi
-	@if [ -z "$(sed -n '/set ratios/p' ~/.config/lf/lfrc)" ]; then\
+	@if [ -z "$(shell sed -n '/set ratios/p' ~/.config/lf/lfrc)" ]; then\
 		sed -i '1 i\set ratios 1:2:3' ~/.config/lf/lfrc ;\
 	fi
 


### PR DESCRIPTION
The Makefile has issues:
- If `~/.config` does not exist, `~/.config/lf` is not created.
- The lfrc statements are always prepended, even if they already exist.

This pull request fixes these issues.