### PR TITLE
Improve image previews

### DIFF
--- a/preview
+++ b/preview
@@ -1,14 +1,9 @@
 #!/usr/bin/env bash
 
-# Calculate where the image should be placed on the screen.
-num="$(printf "%0.f\n" "$(printf "%s\n" "$(tput cols) / 2" | bc)")"
-numb="$(printf "%0.f\n" "$(printf "%s\n" "$(tput cols) - $num - 1" | bc)")"
-numc="$(printf "%0.f\n" "$(printf "%s\n" "$(tput lines) - 2" | bc)")"
-
 image() {
 	if [ -n "$DISPLAY" ]; then
 		declare -p -A cmd=([action]=add [identifier]="PREVIEW" \
-			[x]="$2" [y]="$3" [max_width]="$4" [max_height]="$5" \
+			[x]="$4" [y]="$5" [width]="$(($2-1))" [height]="$(($3-1))" [scaler]="contain" \
 			[path]="$1") > "$FIFO_UEBERZUG"
 		exit 1
 	else
@@ -39,20 +34,20 @@ case "$(printf "%s\n" "$1" | awk '{print tolower($0)}')" in
 	*.pdf)
 		[ ! -f "${CACHE}.jpg" ] && \
 			pdftoppm -jpeg -f 1 -singlefile "$1" "$CACHE"
-		image "${CACHE}.jpg" "$num" 1 "$numb" "$numc"
+		image "${CACHE}.jpg" "$2" "$3" "$4" "$5"
 		;;
 	*.epub)
 		[ ! -f "$CACHE" ] && \
 			epub-thumbnailer "$1" "$CACHE" 1024
-		image "$CACHE" "$num" 1 "$numb" "$numc"
+		image "$CACHE" "$2" "$3" "$4" "$5"
 		;;
 	*.avi|*.mp4|*.wmv|*.dat|*.3gp|*.ogv|*.mkv|*.mpg|*.mpeg|*.vob|*.fl[icv]|*.m2v|*.mov|*.webm|*.ts|*.mts|*.m4v|*.r[am]|*.qt|*.divx)
 		[ ! -f "${CACHE}.jpg" ] && \
 			ffmpegthumbnailer -i "$1" -o "${CACHE}.jpg" -s 0 -q 5
-		image "${CACHE}.jpg" "$num" 1 "$numb" "$numc"
+		image "${CACHE}.jpg" "$2" "$3" "$4" "$5"
 		;;
 	*.bmp|*.jpg|*.jpeg|*.png|*.xpm|*.webp|*.gif)
-		image "$1" "$num" 1 "$numb" "$numc"
+		image "$1" "$2" "$3" "$4" "$5"
 		;;
 	*)
 		if command -v bat > /dev/null 2>&1


### PR DESCRIPTION
- Use native lf previewer arguments (see lf manpage line 622) instead of
hardcoding them. This has the advantage, that image size and position
are automatically adjusted when the ratio of the panes is changed. (Lf passes only the dimensions of the preview pane. This makes things a lot easier.)

- The max_width and max_height options for ueberzug are deprecated (See https://github.com/seebye/ueberzug#add). The
scaler option is now used in instead.