### PR TITLE
Make all the scripts POSIX compliant

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,6 @@ When a SSH-connection has been established, [chafa](https://github.com/hpjansson
 
 
 ## Prerequisites
-This script assumes that the preview pane is using one third of the window which should be the default behaviour for lf, but f you've changed this you will need to add the following line in your **~/.config/lf/lfrc** file:
-```
-set ratios 1:2:3
-```
 
 Besides lf and Überzug you will need to install the following packages:
 

--- a/cleaner
+++ b/cleaner
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 if [ -n "$FIFO_UEBERZUG" ]; then
-	declare -p -A cmd=([action]=remove [identifier]="PREVIEW") > "$FIFO_UEBERZUG"
+	printf '{"action": "remove", "identifier": "PREVIEW"}\n' > "$FIFO_UEBERZUG"
 fi

--- a/lfrun
+++ b/lfrun
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 set -e
 
 cleanup() {
@@ -12,7 +12,7 @@ else
 	[ ! -d "$HOME/.cache/lf" ] && mkdir --parents "$HOME/.cache/lf"
 	export FIFO_UEBERZUG="$HOME/.cache/lf/ueberzug-$$"
 	mkfifo "$FIFO_UEBERZUG"
-	ueberzug layer -s <"$FIFO_UEBERZUG" -p bash &
+	ueberzug layer -s <"$FIFO_UEBERZUG" -p json &
 	exec 3>"$FIFO_UEBERZUG"
 	trap cleanup EXIT
 	lf "$@" 3>&-

--- a/preview
+++ b/preview
@@ -1,10 +1,8 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 image() {
 	if [ -n "$DISPLAY" ]; then
-		declare -p -A cmd=([action]=add [identifier]="PREVIEW" \
-			[x]="$4" [y]="$5" [width]="$(($2-1))" [height]="$(($3-1))" [scaler]="contain" \
-			[path]="$1") > "$FIFO_UEBERZUG"
+		printf '{"action": "add", "identifier": "PREVIEW", "x": "%s", "y": "%s", "width": "%s", "height": "%s", "scaler": "contain", "path": "%s"}\n' "$4" "$5" "$(($2-1))" "$(($3-1))" "$1" > "$FIFO_UEBERZUG"
 		exit 1
 	else
 		chafa "$1" -s "${4}x${5}"


### PR DESCRIPTION
I rewrote all the scripts in strictly POSIX compliant syntax. The only bashisms used in the scripts were the arrays for ueberzug. However, ueberzug supports three different parsers (bash, simple and json). I went with the json parser. This makes the scripts way more portable, because bash is not required anymore.

I also made a slight change to the README, because it still stated, that it is necessary to have lf configured to use the default ratio of 1:2:3. This was already fixed in my last PR.