### PR TITLE
Add JFIF support to preview script

### DIFF
--- a/preview
+++ b/preview
@@ -58,7 +58,7 @@ case "$(printf "%s\n" "$(readlink -f "$1")" | awk '{print tolower($0)}')" in
 			ffmpegthumbnailer -i "$1" -o "${CACHE}.jpg" -s 0 -q 5
 		image "${CACHE}.jpg" "$2" "$3" "$4" "$5"
 		;;
-	*.bmp|*.jpg|*.jpeg|*.png|*.xpm|*.webp|*.gif)
+	*.bmp|*.jpg|*.jpeg|*.png|*.xpm|*.webp|*.gif|*.jfif)
 		image "$1" "$2" "$3" "$4" "$5"
 		;;
 	*.ino)


### PR DESCRIPTION
This just adds `*.jfif` to the previewer script. It works perfectly on my PC.