### PR TITLE
Image-based html preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Besides lf and Überzug you will need to install the following packages:
 * ImageMagick
 * poppler
 * epub-thumbnailer
+* wkhtmltopdf
 * bat (optional - color highlight for text files)
 * chafa (optional - for image preview over SSH or inside Wayland session)
 * unzip (optional - for .zip and .jar files)

--- a/preview
+++ b/preview
@@ -53,6 +53,11 @@ case "$(printf "%s\n" "$(readlink -f "$1")" | awk '{print tolower($0)}')" in
 			epub-thumbnailer "$1" "$CACHE" 1024
 		image "$CACHE" "$2" "$3" "$4" "$5"
 		;;
+	*.html)
+		[ ! -f "$CACHE" ] && \ 
+			wkhtmltopdf "$1" - | pdftoppm -jpeg -f 1 -singlefile - "$CACHE"
+		image "${CACHE}.jpg" "$2" "$3" "$4" "$5"
+		;;
 	*.avi|*.mp4|*.wmv|*.dat|*.3gp|*.ogv|*.mkv|*.mpg|*.mpeg|*.vob|*.fl[icv]|*.m2v|*.mov|*.webm|*.ts|*.mts|*.m4v|*.r[am]|*.qt|*.divx)
 		[ ! -f "${CACHE}.jpg" ] && \
 			ffmpegthumbnailer -i "$1" -o "${CACHE}.jpg" -s 0 -q 5


### PR DESCRIPTION
Adds a new required dependency, wkhtmltopdf. Suitable for html documents not easily read in plain text. (such as those saved by the extension SingleFile)
`wkhtmltopdf` is used in favor of `wkhtmltoimage` as it generates nicer, one-page previews. 