### PR TITLE
Add support for svg files and fix xpm preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Besides lf and Überzug you will need to install the following packages:
 
 * ffmpegthumbnailer
 * ImageMagick
+* librsvg
 * poppler
 * epub-thumbnailer
 * wkhtmltopdf

--- a/preview
+++ b/preview
@@ -71,6 +71,11 @@ case "$(printf "%s\n" "$(readlink -f "$1")" | awk '{print tolower($0)}')" in
 	*.bmp|*.jpg|*.jpeg|*.png|*.xpm|*.webp|*.gif|*.jfif)
 		image "$1" "$2" "$3" "$4" "$5"
 		;;
+	*.svg)
+		[ ! -f "${CACHE}.jpg" ] && \
+			rsvg-convert "$1" -o "${CACHE}.jpg"
+		image "${CACHE}.jpg" "$2" "$3" "$4" "$5"
+		;;
 	*.ino)
 		batorcat --language=cpp "$1"
 		;;

--- a/preview
+++ b/preview
@@ -68,12 +68,17 @@ case "$(printf "%s\n" "$(readlink -f "$1")" | awk '{print tolower($0)}')" in
 			ffmpegthumbnailer -i "$1" -o "${CACHE}.jpg" -s 0 -q 5
 		image "${CACHE}.jpg" "$2" "$3" "$4" "$5"
 		;;
-	*.bmp|*.jpg|*.jpeg|*.png|*.xpm|*.webp|*.gif|*.jfif)
+	*.bmp|*.jpg|*.jpeg|*.png|*.webp|*.gif|*.jfif)
 		image "$1" "$2" "$3" "$4" "$5"
 		;;
 	*.svg)
 		[ ! -f "${CACHE}.jpg" ] && \
 			rsvg-convert "$1" -o "${CACHE}.jpg"
+		image "${CACHE}.jpg" "$2" "$3" "$4" "$5"
+		;;
+	*.xpm)
+		[ ! -f "${CACHE}.jpg" ] && \
+			convert "$1" "${CACHE}.jpg"
 		image "${CACHE}.jpg" "$2" "$3" "$4" "$5"
 		;;
 	*.ino)


### PR DESCRIPTION
I added the ability to preview scalable vector graphics by converting them to jpg using librsvg, which should already be availably or already installed on most distros, since it is a dependendy of ffmpeg.

I also fixed the xpm preview (which did not work at all on my system) by converting it to jpeg first using `convert` (part of imagemagick).